### PR TITLE
Terraform import DNS Mappings for Blog infrastructure

### DIFF
--- a/terraform/environments/production.tfvars
+++ b/terraform/environments/production.tfvars
@@ -4,3 +4,4 @@ region                   = "us-east1"
 cloud_run_min_replica    = 0
 cloud_run_max_replica    = 1
 external_blog_server_url = "tbd"
+host                     = "blog.amplication.com"

--- a/terraform/environments/staging.tfvars
+++ b/terraform/environments/staging.tfvars
@@ -4,3 +4,4 @@ region                   = "us-east1"
 cloud_run_min_replica    = 0
 cloud_run_max_replica    = 1
 external_blog_server_url = "tbd"
+host                     = "staging-blog.amplication.com"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -40,3 +40,16 @@ resource "google_cloud_run_service_iam_member" "run_all_users" {
   role     = "roles/run.invoker"
   member   = "allUsers"
 }
+
+resource "google_cloud_run_domain_mapping" "mapping" {
+  location = var.region
+  name     = var.host
+
+  metadata {
+    namespace = var.project_id
+  }
+
+  spec {
+    route_name = google_cloud_run_service.service.name
+  }
+}

--- a/terraform/readme.md
+++ b/terraform/readme.md
@@ -42,5 +42,22 @@ terraform apply --var-file=environments/staging.tfvars
 ```sh
 export TF_VAR_image=gcr.io/amplication/blog:v1.0.0-example
 terraform init -backend-config="prefix=amplication-blog/production"
-terraform apply --var-file=environments/production.tfvars
+  terraform apply --var-file=environments/production.tfvars
 ```
+
+### Terraform Import
+The DNS Mappings for the Cloud Run service for both `staging` and `production` need to be imported. If changes are required for Cloud Run DNS you'll need to re-import. Follow below steps...
+
+Domain Mapping can be imported using this accepted format:
+
+```
+$ terraform import google_cloud_run_domain_mapping.default locations/{{location}}/namespaces/{{project}}/domainmappings/{{name}}
+```
+
+The current Terraform state is imported like so...
+```sh
+# Staging
+terraform import --var-file=environments/staging.tfvars google_cloud_run_domain_mapping.mapping locations/us-east1/namespaces/amplication/domainmappings/staging-blog.amplication.com
+
+# Production
+terraform import --var-file=environments/production.tfvars google_cloud_run_domain_mapping.mapping locations/us-east1/namespaces/amplication/domainmappings/blog.amplication.com

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -25,3 +25,7 @@ variable "cloud_run_max_replica" {
 variable "external_blog_server_url" {
   type  = string
 }
+
+variable "host" {
+  type  = string
+}


### PR DESCRIPTION
Issues: https://github.com/amplication/blog/issues/1

The DNS Mappings for the Cloud Run service for both `staging` and `production` need to be imported. If changes are required for Cloud Run DNS you'll need to re-import. Follow below steps...

Domain Mapping can be imported using this accepted format:

```
$ terraform import google_cloud_run_domain_mapping.default locations/{{location}}/namespaces/{{project}}/domainmappings/{{name}}
```

The current Terraform state is imported like so...
```sh
# Staging
terraform import --var-file=environments/staging.tfvars google_cloud_run_domain_mapping.mapping locations/us-east1/namespaces/amplication/domainmappings/staging-blog.amplication.com

# Production
terraform import --var-file=environments/production.tfvars google_cloud_run_domain_mapping.mapping locations/us-east1/namespaces/amplication/domainmappings/blog.amplication.com
